### PR TITLE
[BUGFIX] a dot is allowed in firmware image names

### DIFF
--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -26,7 +26,7 @@ define(['sorttable', 'snabbdom', 'd3-interpolate', 'helper', 'utils/node'],
           return a & a;
         }, 0),
         '{MODEL_NORMALIZED}': d.model.toLowerCase()
-          .replace(/[^a-z0-9\-]+/ig, '-')
+          .replace(/[^a-z0-9\.\-]+/ig, '-')
           .replace(/^-+/, '')
           .replace(/-+$/, '')
       };


### PR DESCRIPTION
## Description
This changes the MODEL_NORMALIZED for devices with a dot in their model name.
This reflects the firmware upgrade conversion, which is also allowed to have a dot in the file name.

For example: `gl.inet-gl-ar300m` or `raspberry-pi-model-b-plus-rev-1.2`

## Motivation and Context
This makes it easier to provide the same image source

## How Has This Been Tested?
WIP

## Screenshots/links (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
