### PR TITLE
separate EOL and deprecated devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ docker run -it --rm --name meshviewer-dev \
 
 The configuration documentation is nowhere near finished.
 
-### Deprecation Warning
+### Deprecation and EOL Warning
 
-The deprecation warning can be turned of with `"deprecation_enabled": false` - but we wouldn't suggest it.
+Both the deprecation and the EOL warning can be turned off with `"deprecation_enabled": false` - but we wouldn't suggest it.
 
-You can insert your own HTML into the deprecation warning via `"deprecation_text":""`.
+You can insert custom HTML into the deprecation and eol warning via `"deprecation_text":""` and `"eol_text":""` respectively.
 
 ## Development
 

--- a/config.example.json
+++ b/config.example.json
@@ -67,5 +67,6 @@
   "devicePicturesLicense": "CC-BY-NC-SA 4.0",
   "node_custom": "/[^a-z0-9\\-\\.]/ig",
   "deprecation_text": "Hier kann ein eigener Text für die Deprecation Warning (inkl. HTML) stehen!",
+  "eol_text": "Hier kann ein eigener Text für die End-of-Life Warnung (inkl. HTML) stehen!",
   "deprecation_enabled": true
 }

--- a/lib/config_default.ts
+++ b/lib/config_default.ts
@@ -168,7 +168,9 @@ export interface Config {
   linkInfos: LinkInfo[];
   nodeInfos: NodeInfo[];
   deprecation_enabled: boolean;
+  eol: string[];
   deprecated: string[];
+  eol_text?: string;
   deprecation_text?: string;
   domainNames: Domain[];
   node_custom: string; // Custom node replacement regex
@@ -359,7 +361,7 @@ export const config: Config = {
       fillOpacity: 0.2,
     },
   },
-  deprecated: [
+  eol: [
     "A5-V11",
     "AP121",
     "AP121U",
@@ -453,7 +455,16 @@ export const config: Config = {
     "WD My Net N600",
     "WD My Net N750",
   ],
+  deprecated: [
+    "TP-LINK RE305",
+    "TP-Link RE305 v1",
+    "TP-LINK RE355",
+    "TP-Link RE355 v1",
+    "TP-LINK RE450",
+    "TP-Link RE450 v1",
+  ],
   deprecation_enabled: true,
+  eol_text: undefined,
   deprecation_text: undefined,
   domainNames: [],
   globalInfos: [],

--- a/lib/infobox/node.ts
+++ b/lib/infobox/node.ts
@@ -196,6 +196,7 @@ export function Node(el: HTMLElement, node: NodeData, linkScale: (t: any) => any
     let attributeTable = h("table", { props: { className: "attributes" } }, []);
 
     let showDeprecation = false;
+    let showEol = false;
 
     config.nodeAttr.forEach(function (row) {
       let field = node[String(row.value)];
@@ -207,7 +208,9 @@ export function Node(el: HTMLElement, node: NodeData, linkScale: (t: any) => any
       // Check if device is in list of deprecated devices. If so, display the deprecation warning
       if (config.deprecation_enabled) {
         if (row.name === "node.hardware") {
-          if (config.deprecated && field && config.deprecated.includes(field)) {
+          if (config.eol && field && config.eol.includes(field)) {
+            showEol = true;
+          } else if (config.deprecated && field && config.deprecated.includes(field)) {
             showDeprecation = true;
           }
         }
@@ -223,7 +226,18 @@ export function Node(el: HTMLElement, node: NodeData, linkScale: (t: any) => any
     attributeTable.children.push(h("tr", [h("th", _.t("node.gateway")), showGateway(node)]));
 
     // Deprecation warning
-    if (showDeprecation) {
+    if (showEol) {
+      // Add eol warning to the container
+      newContainer.children.push(
+        h("div", { props: { className: "eol" } }, [
+          h("div", {
+            props: {
+              innerHTML: config.eol_text || _.t("eol"),
+            },
+          }),
+        ]),
+      );
+    } else if (showDeprecation) {
       // Add deprecation warning to the container
       newContainer.children.push(
         h("div", { props: { className: "deprecated" } }, [

--- a/lib/proportions.ts
+++ b/lib/proportions.ts
@@ -128,7 +128,9 @@ export const Proportions = function (filterManager: ReturnType<typeof DataDistri
     let fwDict = count(nodes, ["firmware", "release"]);
     let baseDict = count(nodes, ["firmware", "base"]);
     let deprecationDict = count(nodes, ["model"], function (d) {
-      return config.deprecated && d && config.deprecated.includes(d) ? _.t("yes") : _.t("no");
+      if (config.deprecated && d && config.deprecated.includes(d)) return _.t("deprecation");
+      if (config.eol && d && config.eol.includes(d)) return _.t("eol");
+      return _.t("no");
     });
     let hwDict = count(nodes, ["model"]);
     let geoDict = count(nodes, ["location"], function (d) {

--- a/public/locale/de.json
+++ b/public/locale/de.json
@@ -99,6 +99,9 @@
   "none": "keine",
   "remove": "entfernen",
   "close": "schließen",
-  "deprecation": "Warnung: Dieser Knoten ist veraltet, und wird demnächst nicht mehr unterstützt. Mehr Infos unter <a href='https://openwrt.org/supported_devices/432_warning'>4/32 warning</a>. <br> Wenn du der Eigentümer des Gerätes bist, bitten wir dich, das Gerät zu ersetzen, um weiterhin am Netz teilnehmen zu können.",
+  "deprecation": "deprecated",
+  "deprecation-text": "Warnung: Dieser Knoten ist veraltet, und wird in Zukunft nicht mehr unterstützt. Mehr Infos unter <a href='https://openwrt.org/supported_devices/864_warning'>8/64 warning</a>. <br> Wenn du der Eigentümer des Gerätes bist, bitten wir dich, das Gerät zu ersetzen, um weiterhin am Netz teilnehmen zu können.",
+  "eol": "end-of-life",
+  "eol-text": "Warnung: Dieser Knoten ist veraltet, und nicht mehr unterstützt. Mehr Infos unter <a href='https://openwrt.org/supported_devices/432_warning'>4/32 warning</a>. <br> Wenn du der Eigentümer des Gerätes bist, bitten wir dich, das Gerät zu ersetzen, um weiterhin am Netz teilnehmen zu können.",
   "loading": "%{name} graph (wird generiert)"
 }

--- a/public/locale/en.json
+++ b/public/locale/en.json
@@ -99,6 +99,9 @@
   "none": "none",
   "remove": "remove",
   "close": "close",
-  "deprecation": "This node is deprecated, and will be out of support soon. More information under <a href='https://openwrt.org/supported_devices/432_warning'>4/32 warning</a>.<br>If you're the owner, please replace it with an modern device!",
+  "deprecation": "deprecated",
+  "deprecation-text": "This node is deprecated, and will be out of support soon. More information under <a href='https://openwrt.org/supported_devices/864_warning'>8/64 warning</a>.<br>If you're the owner, please replace it with an modern device!",
+  "eol": "end-of-life",
+  "eol-text": "This node has reached end-of-life, and is not supported anymore. More information under <a href='https://openwrt.org/supported_devices/432_warning'>4/32 warning</a>.<br>If you're the owner, please replace it with an modern device!",
   "loading": "%{name} graph (is generated)"
 }

--- a/scss/modules/_base.scss
+++ b/scss/modules/_base.scss
@@ -91,12 +91,11 @@ strong {
   width: 1px;
 }
 
-.deprecated {
+.deprecation_base {
   padding-left: $button-distance;
   padding-right: $button-distance;
 
   div {
-    background: $color-warning;
     border-radius: 5px;
     color: $color-white;
     font-size: 110%;
@@ -113,6 +112,20 @@ strong {
         text-decoration: none;
       }
     }
+  }
+}
+
+.deprecated {
+  @extend .deprecation_base;
+  div {
+    background: $color-warning;
+  }
+}
+
+.eol {
+  @extend .deprecation_base;
+  div {
+    background: $color-error;
   }
 }
 

--- a/scss/modules/_variables.scss
+++ b/scss/modules/_variables.scss
@@ -14,7 +14,8 @@ $color-24ghz: $color-primary !default;
 $color-5ghz: #e3a619 !default;
 $color-others: #0a9c92 !default;
 
-$color-warning: #c20000 !default;
+$color-warning: Orange !default;
+$color-error: #c20000 !default;
 
 $color-map-background: #f8f4f0 !default;
 


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

Adding a separation between EOL and Deprecated devices.

## Motivation and Context

Adding a separation as 4/32 devices have already reached EOL a while ago and will not be "soon loose support", while at the same time, we have candidates that might loose support soon.

## How Has This Been Tested?

https://map.ffmuc.net as part of https://github.com/freifunkMUC/meshviewer/pull/70

## Screenshots/links:

See https://map.ffmuc.net

![deprecated](https://github.com/freifunk/meshviewer/assets/2787581/878e6ae8-cbbc-485d-bd3e-80badab560a0)
![eol](https://github.com/freifunk/meshviewer/assets/2787581/6728aa13-37b2-45a9-89c3-7c81a8dfacd2)


## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.

This PR resolves #75 