### PR TITLE
[BUGFIX] add WD My Net devices to deprecation

### DIFF
--- a/lib/config_default.ts
+++ b/lib/config_default.ts
@@ -449,6 +449,8 @@ export const config: Config = {
     "Ubiquiti AirRouter",
     "VoCore 8M",
     "VoCore 16M",
+    "WD My Net N600",
+    "WD My Net N750",
   ],
   deprecation_enabled: true,
   deprecation_text: undefined,


### PR DESCRIPTION
## Description

These are deprecated as of https://gluon.readthedocs.io/en/v2022.1/releases/v2022.1.html#removed-devices

I'd like to show this banner for the sole device in FFAC too ;)

## How Has This Been Tested?


## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
