### PR TITLE
[BUGFIX] Fix SimpleNodelist to replace instead of appending new nodes.

### DIFF
--- a/lib/simplenodelist.ts
+++ b/lib/simplenodelist.ts
@@ -13,64 +13,59 @@ export const SimpleNodelist = function (nodesState: string, field: string, title
     render: undefined,
     setData: undefined,
   };
-  let el: HTMLElement;
-  let tbody: HTMLTableSectionElement;
+  let listContainer: VNode = h("div");
 
   self.render = function render(d: HTMLElement) {
-    el = d;
+    let containerEl = document.createElement("div");
+    d.appendChild(containerEl);
+    listContainer = patch(containerEl, listContainer);
   };
 
   self.setData = function setData(data: ObjectsLinksAndNodes) {
     let nodeList = data.nodes[nodesState];
 
-    if (nodeList.length === 0) {
-      tbody = null;
-      return;
-    }
+    let newContainer = h("div");
 
-    if (!tbody) {
-      let h2 = document.createElement("h2");
-      h2.textContent = title;
-      el.appendChild(h2);
+    if (nodeList.length > 0) {
+      let items = nodeList.map(function (node: Node) {
+        let router = window.router;
+        let td0Content: null | VNode = null;
+        if (helper.hasLocation(node)) {
+          td0Content = h("span", { props: { className: "icon ion-location", title: _.t("location.location") } });
+        }
 
-      let table = document.createElement("table");
-      table.classList.add("node-list");
-      el.appendChild(table);
-
-      tbody = document.createElement("tbody");
-      // @ts-ignore
-      tbody.last = h("tbody");
-      table.appendChild(tbody);
-    }
-
-    let items = nodeList.map(function (node: Node) {
-      let router = window.router;
-      let td0Content: null | VNode = null;
-      if (helper.hasLocation(node)) {
-        td0Content = h("span", { props: { className: "icon ion-location", title: _.t("location.location") } });
-      }
-
-      let td1Content = h(
-        "a",
-        {
-          props: {
-            className: ["hostname", node.is_online ? "online" : "offline"].join(" "),
-            href: router.generateLink({ node: node.node_id }),
-          },
-          on: {
-            click: function (e: Event) {
-              router.fullUrl({ node: node.node_id }, e);
+        let td1Content = h(
+          "a",
+          {
+            props: {
+              className: ["hostname", node.is_online ? "online" : "offline"].join(" "),
+              href: router.generateLink({ node: node.node_id }),
+            },
+            on: {
+              click: function (e: Event) {
+                router.fullUrl({ node: node.node_id }, e);
+              },
             },
           },
-        },
-        node.hostname,
-      );
+          node.hostname,
+        );
 
-      return h("tr", [h("td", td0Content), h("td", td1Content), h("td", moment(node[field]).from(data.now))]);
-    });
+        return h("tr", [h("td", td0Content), h("td", td1Content), h("td", moment(node[field]).from(data.now))]);
+      });
 
-    let tbodyNew = h("tbody", items);
-    patch(tbody, tbodyNew);
+      newContainer.children = [
+        h("h2", title),
+        h(
+          "table",
+          {
+            props: { className: "node-list" },
+          },
+          h("tbody", items),
+        ),
+      ];
+    }
+
+    listContainer = patch(listContainer, newContainer);
   };
 
   return self;


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

The actual fix is saving the patched node.
This effectively reverts (part of)
https://github.com/freifunk/meshviewer/commit/005130988965a1ae60f6e83556dce53dc7d2ce75

So the simplest fix would be:
```ts
    patch(tbody, tbodyNew)
```
->
```ts
    tbody = patch(tbody, tbodyNew) as unknown as HTMLTableSectionElement;
```

(however the typing is anyway wrong here, but that doesn't really matter here)

I am not really sure why thats relevant for patch, but I could not get it working without.  
I thought that the patch always replaces the "diff", but maybe I don't understand Snabbdom correctly^^


Also I also noticed that there is an edge case when on the first load the list shows no nodes
and in subsequent reloads it gets nodes, it will append the node list always at the bottom, which may not be correct.

To avoid this and to make it more robust,
this component is now refactored, and uses an extra container div thats always in the dom.

That way it already reserves a place in the dom, even when no nodes are there yet.


If I should split this into a separate pull request, just tell me.  
However as I anyway refactored most code, it did not make sense to me to split this up.

<!-- Describe your changes -->

## Motivation and Context

Closes: #138

And also makes the list more robust to changes (e.g. if the first dataset is empty and further updates contain nodes)

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->
Tested on ff and chrome.

To test the behavior on what happens when there are first no nodes, i temporarily decreased the refresh timer and I also mocked the data.
```ts
let first = true

export const main = () => {
  function handleData(data: { links: Link[]; nodes: Node[]; timestamp: string }[]) {
    // ...
    newnodes = first ? [] : newnodes
    first = false

    return {
      // ...
    };
  }
```
## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [  ] My change requires a change to the documentation.
  - [  ] I have updated the documentation accordingly.
