### PR TITLE
npm: update sass to 1.77.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "eslint": "^8.51.0",
         "eslint-config-prettier": "^9.1.0",
         "prettier": "3.5.2",
-        "sass": "^1.69.7",
+        "sass": "^1.77.8",
         "typescript": "^5.7.2",
         "vite": "^6.3.4",
         "vite-plugin-checker": "^0.6.2",
@@ -6557,10 +6557,11 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.69.7",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.7.tgz",
-      "integrity": "sha512-rzj2soDeZ8wtE2egyLXgOOHQvaC2iosZrkF6v3EUG+tBwEvhqUCzm0VP3k9gHF9LXbSrRhT5SksoI56Iw8NPnQ==",
+      "version": "1.77.8",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.8.tgz",
+      "integrity": "sha512-4UHg6prsrycW20fqLGPShtEvo/WyHRVRHwOP4DzkUrObWoWI05QBSfzU71TVB7PFaL104TwNaHpjlWXAZbQiNQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint": "^8.51.0",
     "eslint-config-prettier": "^9.1.0",
     "prettier": "3.5.2",
-    "sass": "^1.69.7",
+    "sass": "^1.77.8",
     "typescript": "^5.7.2",
     "vite": "^6.3.4",
     "vite-plugin-checker": "^0.6.2",


### PR DESCRIPTION
## Description

npm: update sass to 1.77.8

## Motivation and Context

version of https://github.com/freifunk/meshviewer/pull/144 without deprecation warnings, updating only so far it doesn't yield warnings

## How Has This Been Tested?

local test setup

## Screenshots/links:

-/- 

## Checklist:

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
