### PR TITLE
[BUGFIX] sorting of sortable tables. (#137)

### DIFF
--- a/lib/sorttable.ts
+++ b/lib/sorttable.ts
@@ -1,4 +1,4 @@
-import { classModule, eventListenersModule, h, init, propsModule, styleModule } from "snabbdom";
+import { classModule, eventListenersModule, h, init, propsModule, styleModule, VNode } from "snabbdom";
 import { _ } from "./utils/language.js";
 
 export interface Heading {
@@ -22,6 +22,8 @@ export const SortTable = function (
   let data: any[];
   let sortReverse = false;
   self.el = document.createElement("table");
+
+  let vnode: VNode = null;
 
   function sortTable(i: number) {
     sortReverse = i === sortIndex ? !sortReverse : false;
@@ -72,7 +74,7 @@ export const SortTable = function (
     }
 
     let elNew = h("table", children);
-    patch(self.el, elNew);
+    vnode = patch(vnode ?? self.el, elNew);
   }
 
   self.setData = function setData(d: any[]) {


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

<!-- Describe your changes -->

Similar problem as #149.
However I think I understand it now better:
the example on https://github.com/snabbdom/snabbdom describes that the first patch should be on the dom-element, but the second patch should be on the vnode from before.

So it now saves the last vnode and patch it. Only on the first patch (if vnode is not set yet), it patches the element.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #137 

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->
FF and chrome, mobile and desktop tested 

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->
![image](https://github.com/user-attachments/assets/dfe739ac-7bd7-4c5f-8564-6123865a2ca9)

![image](https://github.com/user-attachments/assets/c0522021-0af4-43e1-8560-a8abec37b3ca)


## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
