### PR TITLE
Darkmode

### DIFF
--- a/lib/map.ts
+++ b/lib/map.ts
@@ -146,15 +146,20 @@ export const Map = function (linkScale: (t: any) => any, sidebar: ReturnType<typ
       map.setZoom(map.options.maxZoom);
     }
 
-    let style: Element & { media?: string } = document.querySelector('.css-mode:not([media="not"])');
-    if (style && e.layer.options.mode !== "" && !style.classList.contains(e.layer.options.mode)) {
-      style.media = "not";
-      labelLayer.updateLayer();
-    }
-    if (e.layer.options.mode) {
-      let newStyle: Element & { media?: string } = document.querySelector(".css-mode." + e.layer.options.mode);
-      newStyle.media = "";
-      newStyle.appendChild(document.createTextNode(""));
+    let html_tag: Element = document.querySelector("html");
+    let class_list = html_tag.classList;
+    class_list.forEach(function (item) {
+      if (item.startsWith("theme_")) {
+        class_list.remove(item);
+      }
+    });
+    if (
+      html_tag &&
+      e.layer.options.mode &&
+      e.layer.options.mode !== "" &&
+      !html_tag.classList.contains(e.layer.options.mode)
+    ) {
+      class_list.add("theme_" + e.layer.options.mode);
       labelLayer.updateLayer();
     }
   });

--- a/scss/main.scss
+++ b/scss/main.scss
@@ -27,3 +27,4 @@
 
 // Make adjustments in custom scss
 @import "custom/custom";
+@import "night";

--- a/scss/night.scss
+++ b/scss/night.scss
@@ -8,7 +8,7 @@ $color-map-background: #0d151c;
 
 $color-online: lighten($color-online, 25%);
 
-html {
+.theme_night {
   //@import 'modules/base';
   body,
   textarea,
@@ -87,10 +87,6 @@ html {
     .container {
       background: transparentize($color-white, 0.03);
       border-right: 1px solid darken($color-white, 10%);
-    }
-
-    img {
-      filter: invert(100%);
     }
 
     @media screen and (max-width: map-get($grid-breakpoints, xl) - 1) {


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

This readds the night-mode as before 
https://github.com/freifunk/meshviewer/commit/860cdd9acf4738236b0e5a515c3c4555fd9a9ffe#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L28

it does not automatically switch with: `window.matchMedia("(prefers-color-scheme: dark)")`.

```
{
    "mapLayers": [
    {
      "name": "EsriWorldImagery",
      "url": "https://tiles.aachen.freifunk.net/EsriWorldImagery/{z}/{y}/{x}.png",
      "config": {
        "maxZoom": 19,
        "start": 30,
        "mode": "night",
        "attribution": "<a href=\"http://arcgis.com/\" target=\"_blank\">&copy; ArcGIS-Satellite</a> <a href=\"http://arcgis.com/about/\" target=\"_blank\">&copy; ArcGIS</a>"
      }
}
```

## Motivation and Context

fixes #97 

## How Has This Been Tested?

Toggling between a theme with and without `"mode": "night",` set.

## Screenshots/links:

![image](https://github.com/user-attachments/assets/bb6198e0-2b42-4989-9b7a-ae573b78a6cf)

The svg is not inverted, everything else works like before.

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
