### PR TITLE
sort firmware versions by name if same count exists

### DIFF
--- a/lib/proportions.ts
+++ b/lib/proportions.ts
@@ -6,6 +6,7 @@ import { GenericNodeFilter } from "./filters/genericnode.js";
 import * as helper from "./utils/helper.js";
 import { _ } from "./utils/language.js";
 import { Node } from "./utils/node.js";
+import { compare } from "./utils/version.js";
 
 type TableNode = {
   element: HTMLTableElement;
@@ -111,6 +112,14 @@ export const Proportions = function (filterManager: ReturnType<typeof DataDistri
       return null;
     }
 
+    function sortVersionCountAndName(a, b) {
+      // descending by count
+      if (b[1] !== a[1]) {
+        return b[1] - a[1];
+      }
+      return compare(a[0], b[0]);
+    }
+
     let gatewayDict = count(nodes, ["gateway"], hostnameOfNodeID);
     let gateway6Dict = count(nodes, ["gateway6"], hostnameOfNodeID);
 
@@ -154,21 +163,9 @@ export const Proportions = function (filterManager: ReturnType<typeof DataDistri
       }),
     );
 
-    tables.firmware = fillTable(
-      "node.firmware",
-      tables.firmware,
-      fwDict.sort(function (a, b) {
-        return b[1] - a[1];
-      }),
-    );
+    tables.firmware = fillTable("node.firmware", tables.firmware, fwDict.sort(sortVersionCountAndName));
 
-    tables.baseversion = fillTable(
-      "node.baseversion",
-      tables.baseversion,
-      baseDict.sort(function (a, b) {
-        return b[1] - a[1];
-      }),
-    );
+    tables.baseversion = fillTable("node.baseversion", tables.baseversion, baseDict.sort(sortVersionCountAndName));
 
     tables.deprecationStatus = fillTable(
       "node.deprecationStatus",

--- a/lib/utils/version.ts
+++ b/lib/utils/version.ts
@@ -1,6 +1,10 @@
 type Version = { epoch: number; upstream: string; debian: string };
 
 const Version = function (v: string) {
+  // remove leading "v" or "V" if present
+  if (v.startsWith("v") || v.startsWith("V")) {
+    v = v.slice(1);
+  }
   let versionResult = /^[a-zA-Z]?([0-9]*(?=:))?:(.*)/.exec(v);
   let version = versionResult && versionResult[2] ? versionResult[2] : v;
   let versionParts = version.split("-");
@@ -21,9 +25,6 @@ Version.prototype.compare = function (b: Version) {
 };
 
 Version.prototype.charCode = function (c: string) {
-  // the lower the character code the lower the version.
-  // if (c === '~') {return 0;} // tilde sort before anything
-  // else
   if (/[a-zA-Z]/.test(c)) {
     return c.charCodeAt(0) - "A".charCodeAt(0) + 1;
   } else if (/[.:+-:]/.test(c)) {
@@ -90,8 +91,8 @@ Version.prototype.compareStrings = function (a: string, b: string) {
   return 0;
 };
 
-export const compare = (a: any[], b: any[]) => {
-  let va = new Version(a[0]);
-  let vb = new Version(b[0]);
+export const compare = (a: string, b: string) => {
+  let va = new Version(a);
+  let vb = new Version(b);
   return vb.compare(va);
 };


### PR DESCRIPTION
## Description

Before, the firmware were not sorted if the count is the same.

This is fixed with this PR.
Furthermore, a leading v is stripped of the version string when comparing to fix wrong orders.

<!-- Describe your changes -->

## Motivation and Context

closes #90

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
