### PR TITLE
add version info on about page

### DIFF
--- a/lib/about.ts
+++ b/lib/about.ts
@@ -39,10 +39,12 @@ export const About = function (picturesSource: string, picturesLicense: string):
           })
         : "") +
       "<h3>Feel free to contribute!</h3>" +
-      "<p>Please support this meshviewer-fork by opening issues or sending pull requests!</p>" +
+      "<p>Please support the meshviewer by opening issues or sending pull requests!</p>" +
       '<p><a href="https://github.com/freifunk/meshviewer">' +
       "https://github.com/freifunk/meshviewer</a></p>" +
-      '<p>Fork maintained by <a href="https://ffm.freifunk.net" target="_blank">Freifunk Frankfurt</a></p>' +
+      "<p>Version: " +
+      __APP_VERSION__ +
+      "</p>" +
       "<h3>AGPL 3</h3>" +
       "<p>Copyright (C) Milan Pässler</p>" +
       "<p>Copyright (C) Nils Schneider</p>" +

--- a/lib/global.d.ts
+++ b/lib/global.d.ts
@@ -4,6 +4,8 @@ import { Router } from "./utils/router.js";
 export {};
 
 declare global {
+  const __APP_VERSION__: string;
+
   interface Window {
     config: Config;
     router: ReturnType<typeof Router>;

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { resolve } from "path";
 import { defineConfig } from "vite";
 import { checker } from "vite-plugin-checker";
 import { VitePWA } from "vite-plugin-pwa";
+import pkg from "./package.json";
 
 export default defineConfig({
   base: "./",
@@ -9,6 +10,9 @@ export default defineConfig({
     alias: {
       "@fonts": resolve(__dirname, "assets/fonts"),
     },
+  },
+  define: {
+    __APP_VERSION__: JSON.stringify(pkg.version),
   },
   build: {
     outDir: "build",


### PR DESCRIPTION
## Description

add version info on the about page.
This is implemented as a global variable, so that is is automagically adjusted with the package.json version

also remove old fork information

## Motivation and Context

It is sometimes not directly visible which meshviewer version is used.
The fork and maintenance information is outdated, so I removed it.

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

![image](https://github.com/user-attachments/assets/83c386ca-b30c-44a7-a4d3-d47c4b36b01c)

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
