### PR TITLE
fix: calculate stats on all nodes

### DIFF
--- a/lib/proportions.ts
+++ b/lib/proportions.ts
@@ -99,8 +99,7 @@ export const Proportions = function (filterManager: ReturnType<typeof DataDistri
   }
 
   self.setData = function setData(data: ObjectsLinksAndNodes) {
-    let onlineNodes = data.nodes.online;
-    let nodes = onlineNodes.concat(data.nodes.lost);
+    let nodes = data.nodes.all;
     time = data.timestamp;
 
     function hostnameOfNodeID(nodeid: string | null) {


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

before, the nodes used for the stats were only all online plus lost nodes. This amount is filtered by maxage, which is confusing and unexpected

This led to issues at @freifunkh, as they do not have a matching age filter in yanic to their meshviewer config.

The `maxAge` config param now only filters the "new Nodes" and "disappeared Nodes" view.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

This issue also exists on graveyard configs, which do not limit the old nodes

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

Run code locally using `npm run dev` and `npm run build`

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
