### PR TITLE
ci: use a fixed action-gh-release version for thirdparty release action

### DIFF
--- a/.github/workflows/release-meshviewer.yml
+++ b/.github/workflows/release-meshviewer.yml
@@ -21,7 +21,7 @@ jobs:
       - run: "cd build; zip -r ../meshviewer-build.zip .; cd .."
       - name: Create and Upload Release Asset
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
as noted in https://github.com/freifunk/meshviewer/pull/184#issuecomment-3018478131, it is better to use a fixed commit version.
