### PR TITLE
fix: loading the json file did create a root application instead returning the cached json

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -28,6 +28,7 @@ export default defineConfig({
     new VitePWA({
       workbox: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg,ttf,woff,woff2}"],
+        navigateFallbackDenylist: [new RegExp(".*\.json")],
       },
       manifest: {
         name: "Meshviewer",


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

This fixes the PWA to not return the application on *.json files.

<!-- Describe your changes -->

## Motivation and Context

The issue appears when visiting the config.json of any meshviewer.
Using curl/wget, one receives the valid json, but in a browser with Service-Worker, the application is returned instead.
This is fixed with this config change.

Besides of the config.json, there is also the `locale/en.json` and thelike, which should not be handled by the service worker as well.
Instead, they are now correctly served by the browser cache.

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

visit /config.json after visiting the application in a private tab.
Before, this did show the meshviewer as well.

Run `npm run build` and `python -m http.server 8089 -d build` to serve this, as the dev server does not have this issue.

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
