### PR TITLE
feat: increase height of info sidebar on small mobile screens

### DIFF
--- a/scss/modules/_map.scss
+++ b/scss/modules/_map.scss
@@ -24,7 +24,7 @@
   }
 
   @media screen and (max-width: map-get($grid-breakpoints, lg) - 1) {
-    height: calc(100vh - 150px);
+    height: 80vh;
     min-height: 240px;
     position: relative;
     width: auto;


### PR DESCRIPTION

## Description

On modern browsers, the lower browser bar hides parts of the lower sidebar, making it hard to scroll to the sidebar.
This is fixed by reducing the size of the map to 80% of the viewport instead of depending on 150px

## Motivation and Context

@grische mentioned this issue on his phone yesterday

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
