### PR TITLE
feat: disable location watching

### DIFF
--- a/lib/map/button.js
+++ b/lib/map/button.js
@@ -105,9 +105,9 @@ export const Button = function (map, buttons) {
 
   function enableTracking() {
     map.locate({
-      watch: true,
+      follow: true,
       enableHighAccuracy: true,
-      setView: true,
+      setView: "untilPan",
     });
     locateUserButton.set(true);
   }


### PR DESCRIPTION
## Description

always zooming back to the user location is quite annoying when wanting to zoom out and changing the view. This is especially useful when viewing your location in relation to a different router.

## Motivation and Context

When having the position activated, a blue marker for the position is shown. This marker always resets the view and zoom after a few seconds to the position.
I don't think that this is the expected behavior.

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
