### PR TITLE
fix: revert unnecessary change to locate - add watch option back

### DIFF
--- a/lib/map/button.js
+++ b/lib/map/button.js
@@ -105,7 +105,7 @@ export const Button = function (map, buttons) {
 
   function enableTracking() {
     map.locate({
-      follow: true,
+      watch: true,
       enableHighAccuracy: true,
       setView: "untilPan",
     });


### PR DESCRIPTION

## Description

watch should be enabled, to update the current location. This was changed by mistake in the previous commit.

## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
