### PR TITLE
fix: firstseen now respects locale and shows a past time

### DIFF
--- a/lib/utils/node.ts
+++ b/lib/utils/node.ts
@@ -135,7 +135,7 @@ self.showUptime = function showUptime(node: Node) {
 };
 
 self.showFirstSeen = function showFirstSeen(node: Node) {
-  return node.firstseen.fromNow(true);
+  return moment.utc(node.firstseen).local().fromNow();
 };
 
 self.showLoad = function showLoad(node: Node) {

--- a/public/locale/de.json
+++ b/public/locale/de.json
@@ -87,9 +87,9 @@
       "d": "einem Tag",
       "dd": "%d Tagen",
       "M": "einem Monat",
-      "MM": "%d Monate",
+      "MM": "%d Monaten",
       "y": "einem Jahr",
-      "yy": "%d Jahre"
+      "yy": "%d Jahren"
     }
   },
   "yes": "ja",


### PR DESCRIPTION
## Description

This fixes the information shown for firstseen

## Motivation and Context

When switching from english to german in an english browser, the english local was used:

<img width="238" height="62" alt="image" src="https://github.com/user-attachments/assets/9a856ab1-e32b-4d4c-9017-4492e92df278" />

This is fixed with this PR.

Furthermore, the correct past prefix is added for the first seen - printing "vor 21 Tagen" as well as in english

<img width="245" height="62" alt="image" src="https://github.com/user-attachments/assets/2feb9600-2324-4241-a050-9d1abad5af79" />


## How Has This Been Tested?

<!-- Please try to test the code in multiple browsers and on a mobile device -->

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
