### PR TITLE
release: bump version to 12.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshviewer",
-  "version": "12.5.0",
+  "version": "12.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshviewer",
-      "version": "12.5.0",
+      "version": "12.6.0",
       "license": "AGPL-3.0",
       "dependencies": {
         "@types/d3-collection": "^1.0.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "meshviewer",
-  "version": "12.5.0",
+  "version": "12.6.0",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This bumps the version to 12.6.0 to officially release the latest changes to the meshviewer.

This includes a fix to the statistics #187 and the new deprecation #81 