### PR TITLE
infobox/chart: support InfluxDB ALIAS BY for multi-series queries

### DIFF
--- a/lib/config_default.ts
+++ b/lib/config_default.ts
@@ -70,6 +70,9 @@ export interface Chart {
   datasourceUid: string;
   datasourceType: string;
   query: string;
+  // InfluxDB ALIAS BY pattern (e.g. "$tag_domain"); names the per-series frames
+  // returned by a GROUP BY tag query. Optional; single-series queries don't need it.
+  alias?: string;
   format?: string;
   unitSuffix?: string;
   from?: string;

--- a/lib/infobox/chart.ts
+++ b/lib/infobox/chart.ts
@@ -82,6 +82,8 @@ async function fetchChartData(
           resultFormat: "time_series",
           intervalMs,
           maxDataPoints,
+          // InfluxDB ALIAS BY, e.g. "$tag_domain" to name per-tag series from a GROUP BY
+          ...(chart.alias ? { alias: applySubst(chart.alias, subst) } : {}),
         },
       ],
       from: fromStr,


### PR DESCRIPTION

<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

A GROUP BY tag InfluxDB query returns one frame per tag value, but without an ALIAS BY pattern those frames come back with the default measurement/field name, so the chart cannot label or colour them per series.

Add an optional Chart.alias config field and forward it to the /api/ds/query request as the InfluxDB query's `alias` property. The pattern (e.g. "$tag_domain") runs through the same substitution as the query. Single-series queries omit it and are unaffected.

## Motivation and Context

We wanted to see clients per segment

## How Has This Been Tested?

https://map.ffmuc.net/#/en/map:~:text=Clients%20pro%20Segment

## Screenshots/links:

### Before
<img width="531" height="896" alt="grafik" src="https://github.com/user-attachments/assets/b4bff193-ef38-49cf-b420-bde87a5eda65" />

### After
<img width="530" height="720" alt="grafik" src="https://github.com/user-attachments/assets/0f85100a-6a2e-48d8-8e95-a23407cb9173" />

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
