### PR TITLE
normalize filter values before comparing them

### DIFF
--- a/lib/filters/genericnode.test.ts
+++ b/lib/filters/genericnode.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("snabbdom", () => ({
+  h: (...args: any[]) => ({ args }),
+}));
+
+vi.mock("leaflet", () => ({}));
+
+vi.mock("../utils/language.js", () => ({
+  _: {
+    t: (key: string) => key,
+  },
+}));
+
+vi.stubGlobal("document", {
+  createElement: () => ({ textContent: "", appendChild: () => {} }),
+});
+
+import { GenericNodeFilter } from "./genericnode.js";
+import { Node } from "../utils/node.js";
+
+function nodeWithModel(model: string | null) {
+  return { node_id: "000000000000", model } as unknown as Node;
+}
+
+describe("GenericNodeFilter", () => {
+  it("matches spelling variants of the same hardware model", () => {
+    const filter = GenericNodeFilter("node.hardware", ["model"], "ZyXEL WSM20", null as any);
+
+    expect(filter.run(nodeWithModel("ZyXEL WSM20"))).toBe(true);
+    expect(filter.run(nodeWithModel("Zyxel WSM20"))).toBe(true);
+  });
+
+  it("matches models padded with whitespace, so filter links survive a reload", () => {
+    const filter = GenericNodeFilter("node.hardware", ["model"], "FUJITSU D2963-A1", null as any);
+
+    expect(filter.run(nodeWithModel("FUJITSU      D2963-A1     "))).toBe(true);
+  });
+
+  it("still separates genuinely different values", () => {
+    const filter = GenericNodeFilter("node.hardware", ["model"], "ZyXEL WSM20", null as any);
+
+    expect(filter.run(nodeWithModel("ZyXEL NWA50AX"))).toBe(false);
+  });
+
+  it("never matches a missing attribute, and keeps it when negated", () => {
+    const filter = GenericNodeFilter("node.hardware", ["model"], "ZyXEL WSM20", null as any);
+
+    expect(filter.run(nodeWithModel(null))).toBe(false);
+
+    filter.setNegate(true);
+    expect(filter.run(nodeWithModel(null))).toBe(true);
+    expect(filter.run(nodeWithModel("ZyXEL WSM20"))).toBe(false);
+  });
+
+  it("gives spelling variants the same key, so they toggle the same filter", () => {
+    const upper = GenericNodeFilter("node.hardware", ["model"], "ZyXEL WSM20", null as any);
+    const lower = GenericNodeFilter("node.hardware", ["model"], "Zyxel WSM20", null as any);
+    const other = GenericNodeFilter("node.hardware", ["model"], "ZyXEL NWA50AX", null as any);
+
+    expect(upper.getKey?.()).toBeDefined();
+    expect(upper.getKey?.()).toBe(lower.getKey?.());
+    expect(upper.getKey?.()).not.toBe(other.getKey?.());
+  });
+
+  it("applies the node value modifier before comparing", () => {
+    const filter = GenericNodeFilter("node.status", ["is_online"], "Online", (d: any) => (d ? "online" : "offline"));
+
+    expect(filter.run({ is_online: true } as unknown as Node)).toBe(true);
+    expect(filter.run({ is_online: false } as unknown as Node)).toBe(false);
+  });
+});

--- a/lib/filters/genericnode.ts
+++ b/lib/filters/genericnode.ts
@@ -13,6 +13,8 @@ export const GenericNodeFilter = function (
   let negate = false;
   let refresh: () => any;
 
+  const normalizedValue = helper.normalizeFilterValue(value);
+
   let label = document.createElement("label");
   let strong = document.createElement("strong");
   label.textContent = _.t(name) + ": ";
@@ -25,7 +27,11 @@ export const GenericNodeFilter = function (
       nodeValue = nodeValueModifier(nodeValue);
     }
 
-    return nodeValue === value ? !negate : negate;
+    if (nodeValue === null || nodeValue === undefined) {
+      return negate;
+    }
+
+    return helper.normalizeFilterValue(nodeValue) === normalizedValue ? !negate : negate;
   }
 
   function setRefresh(f: () => any) {
@@ -62,7 +68,7 @@ export const GenericNodeFilter = function (
   }
 
   function getKey() {
-    return value.concat(name);
+    return normalizedValue.concat(name);
   }
 
   function getName() {

--- a/lib/proportions.ts
+++ b/lib/proportions.ts
@@ -104,12 +104,7 @@ export const Proportions = function (filterManager: ReturnType<typeof DataDistri
   // flag set while we apply filters programmatically from the URL hash
   let appliedUrlFilters = false;
 
-  function normalizeKey(s: string | null | undefined) {
-    if (!s) return "";
-    return String(s).replace(/\s+/g, " ").trim();
-  }
-
-  function count(nodes: Node[], keys: string[], nodeValueModifier?: (k: any, ctx?: any) => any, ctx?: any) {
+  function count(nodes: Node[], keys: string[], nodeValueModifier?: (k: any, ctx?: any) => any, ctx?: any): any[][] {
     const counts = new Map<any, number>();
 
     nodes.forEach(function (node) {
@@ -120,17 +115,14 @@ export const Proportions = function (filterManager: ReturnType<typeof DataDistri
         dictKey = nodeValueModifier(dictKey, ctx);
       }
 
-      if (dictKey === null) return;
+      if (dictKey === null || dictKey === undefined) return;
 
       counts.set(dictKey, (counts.get(dictKey) || 0) + 1);
     });
 
-    const result: any[] = [];
-    counts.forEach(function (countValue, k) {
-      result.push([k, countValue, keys, nodeValueModifier]);
+    return helper.mergeSpellingVariants(counts).map(function ([value, total]) {
+      return [value, total, keys, nodeValueModifier];
     });
-
-    return result;
   }
 
   function addFilter(filter: Filter) {
@@ -297,8 +289,8 @@ export const Proportions = function (filterManager: ReturnType<typeof DataDistri
         let filter = GenericNodeFilter(
           param,
           mapping.keys,
-          normalizeKey(encodedValue),
-          mapping.nodeValueModifier ?? ((v: unknown) => String(v)),
+          helper.collapseWhitespace(encodedValue),
+          mapping.nodeValueModifier ?? ((v: unknown) => (v === null || v === undefined ? null : String(v))),
         );
         if (negate) {
           filter.setNegate(true);

--- a/lib/utils/helper.test.ts
+++ b/lib/utils/helper.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("snabbdom", () => ({
+  h: (...args: any[]) => ({ args }),
+}));
+
+vi.mock("leaflet", () => ({}));
+
+vi.mock("./language.js", () => ({
+  _: {
+    t: (key: string) => key,
+  },
+}));
+
+import { mergeSpellingVariants } from "./helper.js";
+
+describe("mergeSpellingVariants", () => {
+  it("merges case variants and labels them with the most common spelling", () => {
+    const merged = mergeSpellingVariants(
+      new Map<unknown, number>([
+        ["ZyXEL WSM20", 42],
+        ["Zyxel WSM20", 12],
+        ["TP-LINK Archer C7 v5", 1],
+        ["TP-Link Archer C7 v5", 101],
+      ]),
+    );
+
+    expect(merged).toEqual([
+      ["TP-Link Archer C7 v5", 102],
+      ["ZyXEL WSM20", 54],
+    ]);
+  });
+
+  it("collapses padding whitespace in labels", () => {
+    const merged = mergeSpellingVariants(new Map<unknown, number>([["FUJITSU      D2963-A1     ", 1]]));
+
+    expect(merged).toEqual([["FUJITSU D2963-A1", 1]]);
+  });
+
+  it("labels a tie alphabetically rather than by input order", () => {
+    const counts: [unknown, number][] = [
+      ["Zyxel WSM20", 5],
+      ["ZyXEL WSM20", 5],
+    ];
+
+    expect(mergeSpellingVariants(new Map(counts))).toEqual([["ZyXEL WSM20", 10]]);
+    expect(mergeSpellingVariants(new Map(counts.reverse()))).toEqual([["ZyXEL WSM20", 10]]);
+  });
+
+  it("keeps genuinely different values apart", () => {
+    const merged = mergeSpellingVariants(
+      new Map<unknown, number>([
+        ["ZyXEL WSM20", 42],
+        ["ZyXEL NWA50AX", 3],
+      ]),
+    );
+
+    expect(merged).toHaveLength(2);
+  });
+});

--- a/lib/utils/helper.ts
+++ b/lib/utils/helper.ts
@@ -1,6 +1,6 @@
 import { Moment } from "moment";
 import { h, VNode } from "snabbdom";
-import { Map } from "leaflet";
+import { Map as LeafletMap } from "leaflet";
 import { _ } from "./language.js";
 import { Node } from "./node.js";
 import { LinkInfo } from "../config_default.js";
@@ -181,7 +181,7 @@ export const showDevicePicture = function showDevicePicture(pictures: string, su
   });
 };
 
-export const getTileBBox = function getTileBBox(size: Point, map: Map, tileSize: number, margin: number) {
+export const getTileBBox = function getTileBBox(size: Point, map: LeafletMap, tileSize: number, margin: number) {
   let tl = map.unproject([size.x - margin, size.y - margin]);
   let br = map.unproject([size.x + margin + tileSize, size.y + margin + tileSize]);
 

--- a/lib/utils/helper.ts
+++ b/lib/utils/helper.ts
@@ -69,6 +69,41 @@ export const dictGet = function dictGet(dict: { [x: string]: any }, keys: string
   return dictGet(dict[key], keys);
 };
 
+// Firmware versions spell the same value differently ("ZyXEL WSM20" became
+// "Zyxel WSM20" in newer OpenWrt), splitting it across unfilterable rows.
+export const collapseWhitespace = function collapseWhitespace(value: unknown) {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value).replace(/\s+/g, " ").trim();
+};
+
+export const normalizeFilterValue = function normalizeFilterValue(value: unknown) {
+  return collapseWhitespace(value).toLowerCase();
+};
+
+// The sort makes the most common spelling win the label, deterministically.
+export const mergeSpellingVariants = function mergeSpellingVariants(counts: Map<unknown, number>) {
+  const merged = new Map<string, [string, number]>();
+
+  [...counts]
+    .sort(function (a, b) {
+      return b[1] - a[1] || (String(a[0]) < String(b[0]) ? -1 : 1);
+    })
+    .forEach(function ([value, count]) {
+      const key = normalizeFilterValue(value);
+      const group = merged.get(key);
+
+      if (group === undefined) {
+        merged.set(key, [collapseWhitespace(value), count]);
+      } else {
+        group[1] += count;
+      }
+    });
+
+  return [...merged.values()];
+};
+
 export const listReplace = function listReplace(template: string, subst: ReplaceMapping) {
   for (const [key, value] of Object.entries(subst)) {
     let re = new RegExp(key, "g");


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

Ignores whitespaces and make device type filters case-insensitive.

## Motivation and Context

With OpenWrt renaming ZyXEL to Zyxel, the filters in the map are ambigious at best. This PR allows filtering even if they are using different version of Gluon/OpenWrt.

## How Has This Been Tested?

https://map.ffmuc.net/

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
