### PR TITLE
map: invert vector map in dark mode

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -56,13 +56,14 @@ Defines a List of Maps that are used as a background.
       "url": "https://sgx.geodatenzentrum.de/gdz_basemapworld_vektor/styles/bm_web_wld_col.json",
       "type": "vector",
       "config": {
+        "invertInDarkMode": true,
         "attribution": "&copy; basemap.de / <a href='https://www.bkg.bund.de'>BKG</a> (2025) <a href='https://creativecommons.org/licenses/by/4.0/'>CC BY 4.0</a>; Datenquellen: &copy; GeoBasis-DE / <a href='https://www.bkg.bund.de'>BKG</a> (2025) <a href='https://creativecommons.org/licenses/by/4.0/'>CC BY 4.0</a>; außerhalb Deutschlands: &copy; <a href='https://www.openstreetmap.org/copyright'>Open Street Map Mitwirkende ODbL v. 1.0</a> ; © <a href='https://openmaptiles.org/'>OpenMapTiles</a>"
       }
     }
   ],
 ```
 
-The `invertInDarkMode` boolean allows you to automatically invert standard map tiles (like light OpenStreetMap) via CSS when the app switches to dark mode, matching the dark aesthetic without needing a dedicated dark tile server. Note that this property is ignored for vector map layers.
+The `invertInDarkMode` boolean allows you to automatically invert standard map tiles (like light OpenStreetMap) via CSS when the app switches to dark mode, matching the dark aesthetic without needing a dedicated dark tile server. It works for raster tile layers as well as for vector layers, where the filter is applied to the rendered WebGL canvas.
 
 `fixedCenter` defines the default area that is visible when opening the map.
 

--- a/config.example.json
+++ b/config.example.json
@@ -17,6 +17,7 @@
     {
       "name": "BaseMap.de (Vektor)",
       "url": "https://sgx.geodatenzentrum.de/gdz_basemapworld_vektor/styles/bm_web_wld_col.json",
+      "invertInDarkMode": true,
       "type": "vector",
       "config": {
         "attribution": "&copy; basemap.de / <a href='https://www.bkg.bund.de'>BKG</a> (2025) <a href='https://creativecommons.org/licenses/by/4.0/'>CC BY 4.0</a>; Datenquellen: &copy; GeoBasis-DE / <a href='https://www.bkg.bund.de'>BKG</a> (2025) <a href='https://creativecommons.org/licenses/by/4.0/'>CC BY 4.0</a>; außerhalb Deutschlands: &copy; <a href='https://www.openstreetmap.org/copyright'>Open Street Map Mitwirkende ODbL v. 1.0</a> ; © <a href='https://openmaptiles.org/'>OpenMapTiles</a>"

--- a/dev-fixtures/config.json
+++ b/dev-fixtures/config.json
@@ -77,6 +77,15 @@
         "start": 30,
         "attribution": "&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> | Map Data &copy;  <a href=\"http://arcgis.com/about/\" target=\"_blank\">ArcGIS Sattelite</a>"
       }
+    },
+    {
+      "name": "BaseMap.de (Vektor)",
+      "url": "https://sgx.geodatenzentrum.de/gdz_basemapworld_vektor/styles/bm_web_wld_col.json",
+      "type": "vector",
+      "config": {
+        "invertInDarkMode": true,
+        "attribution": "&copy; basemap.de / <a href='https://www.bkg.bund.de'>BKG</a> (2025) <a href='https://creativecommons.org/licenses/by/4.0/'>CC BY 4.0</a>; Datenquellen: &copy; GeoBasis-DE / <a href='https://www.bkg.bund.de'>BKG</a> (2025) <a href='https://creativecommons.org/licenses/by/4.0/'>CC BY 4.0</a>; außerhalb Deutschlands: &copy; <a href='https://www.openstreetmap.org/copyright'>Open Street Map Mitwirkende ODbL v. 1.0</a> ; © <a href='https://openmaptiles.org/'>OpenMapTiles</a>"
+      }
     }
   ]
 }

--- a/lib/map.ts
+++ b/lib/map.ts
@@ -103,7 +103,8 @@ export const Map = function (linkScale: (t: any) => any, sidebar: ReturnType<typ
               style: layer.url,
               attributionControl: { customAttribution: layerConfig.attribution },
               maxZoom: layerConfig.maxZoom,
-            })
+              className: layerConfig.className,
+            } as L.LeafletMaplibreGLOptions)
           : L.tileLayer(
               layer.url.replace(
                 "{format}",


### PR DESCRIPTION
<!-- Use a prefix like [TASK], [BUGFIX], [DOC] etc. and provide a general summary of your changes in the title above -->
<!-- Everything between these comment tags is hidden from the issue and just there to guide you. -->

## Description

This allows for vector maps to also be inverted in dark mode

## Motivation and Context

Vector maps were very light before.

## How Has This Been Tested?

locally, npm run dev

## Screenshots/links:

<!-- Add screenshots of changed code if visual output has changed / is more complex. -->
<!-- Include both before and after screenshots to easily compare and discuss changes when available. -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project. (CI will test it anyway and also needs approval)
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
